### PR TITLE
Update composer.json to support Symfony ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.6",
     "contao/core-bundle": "^4.13 || ^5.0",
-    "symfony/http-kernel": "^5.0 || ^6.0"
+    "symfony/http-kernel": "^5.0 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "contao/manager-plugin": "~2.2"


### PR DESCRIPTION
If you install hero-element into a new Contao 5 installation, all Symfony packages will be downgraded to version 6. 

This is the fix. And it obviously works in my test install